### PR TITLE
#3 BeatLeaderで開くが404になるのを修正

### DIFF
--- a/MyBeatSaberScore/APIs/BeatLeader.cs
+++ b/MyBeatSaberScore/APIs/BeatLeader.cs
@@ -22,7 +22,7 @@ namespace MyBeatSaberScore.APIs
         /// <returns></returns>
         public static async Task<LeaderboardsResponse> GetLeaderboardsByHash(string hash)
         {
-            string url = $"https://api.beatleader.xyz/leaderboards/hash//{hash}";
+            string url = $"https://api.beatleader.xyz/leaderboards/hash/{hash}";
 
             try
             {


### PR DESCRIPTION
APIのURLにスラッシュが余分についているせいで存在しないリソースを指定した扱いになっていたので直した。